### PR TITLE
Adding option to disable host name verification in forward plugin

### DIFF
--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -33,6 +33,7 @@ type Forward struct {
 
 	tlsConfig     *tls.Config
 	tlsServerName string
+	tlsSkipVerify bool
 	maxfails      uint32
 	expire        time.Duration
 

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -123,6 +123,9 @@ func ParseForwardStanza(c *caddyfile.Dispenser) (*Forward, error) {
 	if f.tlsServerName != "" {
 		f.tlsConfig.ServerName = f.tlsServerName
 	}
+	if f.tlsSkipVerify {
+		f.tlsConfig.InsecureSkipVerify = true
+	}
 	for i := range f.proxies {
 		// Only set this for proxies that need it.
 		if transports[i] == transport.TLS {
@@ -194,6 +197,8 @@ func parseBlock(c *caddyfile.Dispenser, f *Forward) error {
 			return c.ArgErr()
 		}
 		f.tlsServerName = c.Val()
+	case "tls_skip_verify" :
+		f.tlsSkipVerify = true
 	case "expire":
 		if !c.NextArg() {
 			return c.ArgErr()


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Enables disabling host name verification by setting InsecureSkipVerify to true
### 2. Which issues (if any) are related?
none
### 3. Which documentation changes (if any) need to be made?
Add additional option "tls_skip_verify" to the options under tls in the forward plugin
### 4. Does this introduce a backward incompatible change or deprecation?
Will default to host name verification if left out so is backwards compatible 